### PR TITLE
Test direct markdown insertion of anchor link

### DIFF
--- a/29.-references.md
+++ b/29.-references.md
@@ -20,7 +20,7 @@
 | \[ISO10646\] | Universal Coded Character Set [https://www.iso.org/standard/69119.html](https://www.iso.org/standard/69119.html) |
 | \[ISO8601\] | Date and Time Format - ISO 8601 [http://www.iso.org/iso/home/standards/iso8601.htm](http://www.iso.org/iso/home/standards/iso8601.htm) |
 | \[JavaRegex\]  | Oracle, "Class Pattern,"  [http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html](http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html) |
-| \[OBSOLETE\_DFDL\]  | Michael J Beckerle, Stephen M Hanson, Alan W Powell.  GFD-P-R.174: Data Format Description Language \(DFDL\) v1.0 Specification.  Open Grid Forum.  January 2011. [http://www.ogf.org/documents/GFD.174.pdf](http://www.ogf.org/documents/GFD.174.pdf) |
+| [\[OBSOLETE\_DFDL\]](#obsolete-dfdl)  | Michael J Beckerle, Stephen M Hanson, Alan W Powell.  GFD-P-R.174: Data Format Description Language \(DFDL\) v1.0 Specification.  Open Grid Forum.  January 2011. [http://www.ogf.org/documents/GFD.174.pdf](http://www.ogf.org/documents/GFD.174.pdf) |
 | \[IANATimeZone\]  | IANA - Internet Assigned Numbers Authority, "Time Zone Database,"  [http://www.iana.org/time-zones](http://www.iana.org/time-zones) |
 | \[JSON\] | Introducing JSON [http://www.json.org](http://www.json.org/) |
 | \[NETCDF\] | Network Common Data Form \(NetCDF\) [http://www.unidata.ucar.edu/software/netcdf/](http://www.unidata.ucar.edu/software/netcdf/) |


### PR DESCRIPTION
Attempt to use direct markdown link syntax to make linkable anchor for the OBSOLETE_DFDL reference as a test of formatting links